### PR TITLE
Add CertificateManager class

### DIFF
--- a/source/nanoFramework.System.Net/Security/CertificateManager.cs
+++ b/source/nanoFramework.System.Net/Security/CertificateManager.cs
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace System.Net.Security
+{
+    /// <summary>
+    /// Provides an interface to the device certificate store to manage <see cref="X509Certificate"/>.
+    /// </summary>
+    public static class CertificateManager
+    {
+        /// <summary>
+        /// Adds a Certificate Authority Root bundle <see cref="X509Certificate"/> to the store.
+        /// If there is already a CA Root bundle it will be replaced with this one.
+        /// </summary>
+        /// <param name="ca">The Certificate Authority certificate bundle to be added store.</param>
+        /// <returns>
+        /// True if the certificate bundle was correctly added to the device certificate store.
+        /// </returns>
+        /// <remarks>
+        /// This method is exclusive of nanoFramework. There is no equivalent in .NET framework.
+        /// </remarks>
+        public static bool AddCaCertificateBundle(X509Certificate[] ca)
+        {
+            // build a string concatenating all the certificates
+            StringBuilder bundle = new StringBuilder();
+
+            foreach(X509Certificate cert in ca)
+            {
+                byte[] certRaw = cert.GetRawCertData();
+
+                // remove the terminator from each string
+                bundle.Append(Encoding.UTF8.GetString(certRaw, 0, certRaw.Length - 1));
+            }
+
+            // add terminator
+            bundle.Append("\0");
+
+            return AddCaCertificateBundle(bundle.ToString());
+        }
+
+        /// <summary>
+        /// Adds a Certificate Authority Root bundle <see cref="X509Certificate"/> to the store.
+        /// If there is already a CA Root bundle it will be replaced with this one.
+        /// </summary>
+        /// <param name="ca">The Certificate Authority certificate bundle to be added store.</param>
+        /// <returns>
+        /// True if the certificate bundle was correctly added to the device certificate store.
+        /// </returns>
+        /// <remarks>
+        /// This method is exclusive of nanoFramework. There is no equivalent in .NET framework.
+        /// </remarks>
+        public static bool AddCaCertificateBundle(string ca)
+        {
+            return AddCaCertificateBundle(Encoding.UTF8.GetBytes(ca));
+        }
+
+        /// <summary>
+        /// Adds a Certificate Authority Root bundle <see cref="X509Certificate"/> to the store.
+        /// If there is already a CA Root bundle it will be replaced with this one.
+        /// </summary>
+        /// <param name="ca">The Certificate Authority certificate bundle to be added store.</param>
+        /// <returns>
+        /// True if the certificate bundle was correctly added to the device certificate store.
+        /// </returns>
+        /// <remarks>
+        /// This method is exclusive of nanoFramework. There is no equivalent in .NET framework.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern bool AddCaCertificateBundle(byte[] ca);
+    }
+}

--- a/source/nanoFramework.System.Net/Security/NetworkSecurity.cs
+++ b/source/nanoFramework.System.Net/Security/NetworkSecurity.cs
@@ -76,9 +76,6 @@ namespace System.Net.Security
         internal static extern int SecureClientInit(int sslProtocols, int sslCertVerify, X509Certificate certificate, X509Certificate ca);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern void UpdateCertificates(int contextHandle, X509Certificate certificate, X509Certificate[] ca);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void SecureAccept(int contextHandle, object socket);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/source/nanoFramework.System.Net/Security/SslStream.cs
+++ b/source/nanoFramework.System.Net/Security/SslStream.cs
@@ -113,18 +113,6 @@ namespace System.Net.Security
             Authenticate(true, "", null, serverCertificate,  sslProtocols);
         }
 
-        /// <summary>
-        /// Updates the SSL stack to use updated certificates.
-        /// </summary>
-        /// <param name="cert">The personal certificate to update.</param>
-        /// <param name="ca">The certificate authority certificate to update.</param>
-        public void UpdateCertificates(X509Certificate cert, X509Certificate[] ca)
-        {
-            if(_sslContext == -1) throw new InvalidOperationException();
-            
-            SslNative.UpdateCertificates(_sslContext, cert, ca);
-        }
-
         internal void Authenticate(bool isServer, string targetHost, X509Certificate certificate, X509Certificate ca, params SslProtocols[] sslProtocols)
         {
             SslProtocols vers = (SslProtocols)0;

--- a/source/nanoFramework.System.Net/System.Net.nfproj
+++ b/source/nanoFramework.System.Net/System.Net.nfproj
@@ -66,6 +66,7 @@
     <Compile Include="NetworkInformation\NetworkInterfaceType.cs" />
     <Compile Include="NetworkInformation\Wireless80211Configuration.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Security\CertificateManager.cs" />
     <Compile Include="Security\NetworkSecurity.cs" />
     <Compile Include="Security\SslStream.cs" />
     <Compile Include="SocketAddress.cs" />
@@ -98,7 +99,6 @@
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.0.2.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.2\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />


### PR DESCRIPTION
## Description
- Add CertificateManager class.
- Add methods that allow adding/updating a CA Root certificate bundle to the device certificate store.
- ❗️❗️ **Remove `UpdateCertificates` method from `SslStream`** ❗️❗️ (and respective call in SslNative).

## Motivation and Context
- The existing implementation lacks proper management of a X509 "certificate store". The only available method close to this was `UpdateCertificates` which was part of `SslStream`. Clearly not suitable for a regular use case where a certificate must exist on the SLL context prior to creating an SslStream and call any authenticate method.
- Addresses an [issue](https://github.com/NETMF/netmf-interpreter/issues/251) and a _kind-of_ design flaw inherited from .NETMF .

## How Has This Been Tested?<!-- (if applicable) -->
- SSL sample from samples repo.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
