### PR TITLE
Rework SslStream API

### DIFF
--- a/source/nanoFramework.System.Net/Security/NetworkSecurity.cs
+++ b/source/nanoFramework.System.Net/Security/NetworkSecurity.cs
@@ -70,10 +70,10 @@ namespace System.Net.Security
     internal static class SslNative
     {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern int SecureServerInit(int sslProtocols, int sslCertVerify, X509Certificate certificate, X509Certificate[] ca);
+        internal static extern int SecureServerInit(int sslProtocols, int sslCertVerify, X509Certificate certificate, X509Certificate ca);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern int SecureClientInit(int sslProtocols, int sslCertVerify, X509Certificate certificate, X509Certificate[] ca);
+        internal static extern int SecureClientInit(int sslProtocols, int sslCertVerify, X509Certificate certificate, X509Certificate ca);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void UpdateCertificates(int contextHandle, X509Certificate certificate, X509Certificate[] ca);


### PR DESCRIPTION
## Description
- Remove SslVerification from method parameters. It's now exposed as property.
- Rework methods to replace X509 certificate collections to single instance.
- Rework methods to use parameters matching the .NET API.
- Rework calls to SslNative accordingly.

## Motivation and Context
- No point on using a certificate collection on embedded devices for authentication. If not on the CA root certificate store, the usual use case is to use a single specific certificate to authenticate.
- The default authentication option was not to validate certificate, which is clearly, a bad practice.
- The new default behaviour is now to authenticate. The SslVerification property allow a developer to change that behaviour, if needed.
- API is now inline with the .NET one.

## How Has This Been Tested?<!-- (if applicable) -->
- SSL sample pack from sample repo running on a STM32F769I-DISCO.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
