### PR TITLE
Add SocketType property to Socket

### DIFF
--- a/source/nanoFramework.System.Net/Sockets/NetworkStream.cs
+++ b/source/nanoFramework.System.Net/Sockets/NetworkStream.cs
@@ -112,7 +112,8 @@ namespace System.Net.Sockets
             // Set the internal socket
             _socket = socket;
 
-            _socketType = (int)_socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Type);
+           // set the socket type
+            _socketType = (int)socket.SocketType;
 
             _ownsSocket = ownsSocket;
         }


### PR DESCRIPTION
## Description
- Add SocketType property to Socket. Filled in in constructor.

## Motivation and Context
- TI SimpleLink get socket option doesn't implement this.
- This is required in NetworkStream constructor for secure stream. It's fundamental in order to have support for secure sockets. 
- The implementation is not "expensive" on any perspective and it brings minor savings in native code size.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>