### PR TITLE
Fix missing setting of socket type

### DIFF
--- a/source/nanoFramework.System.Net/Sockets/Socket.cs
+++ b/source/nanoFramework.System.Net/Sockets/Socket.cs
@@ -393,6 +393,10 @@ namespace System.Net.Sockets
 
             Socket socket = new Socket(socketHandle);
 
+            // creating a socket from Accept() is only possible for Stream sockets
+            // have to set the type here
+            socket._socketType = SocketType.Stream;
+
             socket.m_localEndPoint = this.m_localEndPoint;
 
             return socket;


### PR DESCRIPTION
## Description
- Have to set socket type on Accept().

## Motivation and Context
- After #67 socket type property has to be set.
- According to Berkley sockets definitions, when processing `Accept()` on a socket the socket type can only be a stream socket. See [here](https://en.wikipedia.org/wiki/Berkeley_sockets#accept) and [here](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socket?view=netframework-4.7.2#remarks).

## How Has This Been Tested?<!-- (if applicable) -->
- HTTP sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
