### PR TITLE
Add remote end point field to Socket

### DIFF
--- a/source/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/source/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("1.0.6.0")]
+[assembly: AssemblyNativeVersion("1.0.7.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/source/nanoFramework.System.Net/Sockets/Socket.cs
+++ b/source/nanoFramework.System.Net/Sockets/Socket.cs
@@ -24,6 +24,7 @@ namespace System.Net.Sockets
 
         private bool m_fBlocking = true;
         private EndPoint m_localEndPoint = null;
+        private EndPoint _remoteEndPoint = null;
 
         // timeout values are stored in uSecs since the Poll method requires it.
         private int m_recvTimeout = System.Threading.Timeout.Infinite;
@@ -312,6 +313,9 @@ namespace System.Net.Sockets
             {
                 throw new ObjectDisposedException();
             }
+
+            // store remote endpoint we are connecting to
+            _remoteEndPoint = remoteEP;
 
             NativeSocket.connect(this, remoteEP.Serialize().m_Buffer, !m_fBlocking);
 


### PR DESCRIPTION
## Description
- Add remote end point field to Socket.
- Bump native version to 1.0.7.0.

## Motivation and Context
- TI SimpleLink API requires on some calls the details of the remote endpoint where the socket is connected to, therefore we need to store this when connecting.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
