### PR TITLE
Major rework on Sockets

### DIFF
--- a/source/nanoFramework.System.Net/IPEndPoint.cs
+++ b/source/nanoFramework.System.Net/IPEndPoint.cs
@@ -19,13 +19,17 @@ namespace System.Net
         /// Specifies the minimum value that can be assigned to the Port property. This field is read-only.
         /// </summary>
         public const int MinPort = 0x00000000;
+        
         /// <summary>
         /// Specifies the maximum value that can be assigned to the Port property. The MaxPort value is set to 0x0000FFFF. This field is read-only.
         /// </summary>
         public const int MaxPort = 0x0000FFFF;
 
-        private IPAddress m_Address;
-        private int m_Port;
+        [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
+        private IPAddress _address;
+
+        [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
+        private int _port;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IPEndPoint"/> class with the specified address and port number.
@@ -34,8 +38,8 @@ namespace System.Net
         /// <param name="port">The port number associated with the address, or 0 to specify any available port. port is in host order.</param>
         public IPEndPoint(long address, int port)
         {
-            m_Port = port;
-            m_Address = new IPAddress(address);
+            _port = port;
+            _address = new IPAddress(address);
         }
 
         /// <summary>
@@ -45,8 +49,8 @@ namespace System.Net
         /// <param name="port"></param>
         public IPEndPoint(IPAddress address, int port)
         {
-            m_Port = port;
-            m_Address = address;
+            _port = port;
+            _address = address;
         }
 
         /// <summary>
@@ -57,7 +61,19 @@ namespace System.Net
         {
             get
             {
-                return m_Address;
+                return _address;
+            }
+        }
+
+        /// <summary>
+        /// Gets the Internet Protocol (IP) address family.
+        /// </summary>
+        /// <value>Returns <see cref="AddressFamily.InterNetwork"/>.</value>
+        public AddressFamily AddressFamily
+        {
+            get
+            {
+                return _address.AddressFamily;
             }
         }
 
@@ -69,7 +85,7 @@ namespace System.Net
         {
             get
             {
-                return m_Port;
+                return _port;
             }
         }
 
@@ -86,13 +102,13 @@ namespace System.Net
             //
             // populate it
             //
-            buffer[2] = unchecked((byte)(this.m_Port >> 8));
-            buffer[3] = unchecked((byte)(this.m_Port));
+            buffer[2] = unchecked((byte)(_port >> 8));
+            buffer[3] = unchecked((byte)(_port));
 
-            buffer[4] = unchecked((byte)(this.m_Address.m_Address));
-            buffer[5] = unchecked((byte)(this.m_Address.m_Address >> 8));
-            buffer[6] = unchecked((byte)(this.m_Address.m_Address >> 16));
-            buffer[7] = unchecked((byte)(this.m_Address.m_Address >> 24));
+            buffer[4] = unchecked((byte)(_address._address));
+            buffer[5] = unchecked((byte)(_address._address >> 8));
+            buffer[6] = unchecked((byte)(_address._address >> 16));
+            buffer[7] = unchecked((byte)(_address._address >> 24));
 
             return socketAddress;
         }
@@ -109,7 +125,7 @@ namespace System.Net
 
             byte[] buf = socketAddress.m_Buffer;
 
- //           Debug.Assert(socketAddress.Family == AddressFamily.InterNetwork);
+            //           Debug.Assert(socketAddress.Family == AddressFamily.InterNetwork);
 
             int port = (int)(
                     (buf[2] << 8 & 0xFF00) |
@@ -123,9 +139,7 @@ namespace System.Net
                     (buf[7] << 24)
                     ) & 0x00000000FFFFFFFF;
 
-            IPEndPoint created = new IPEndPoint(address, port);
-
-            return created;
+            return new IPEndPoint(address, port);
         }
 
         /// <summary>
@@ -134,7 +148,7 @@ namespace System.Net
         /// <returns>A string containing the IP address and the port number of the specified endpoint (for example, 192.168.1.2:80).</returns>
         public override string ToString()
         {
-            return m_Address.ToString() + ":" + m_Port.ToString();
+            return _address.ToString() + ":" + _port.ToString();
         }
 
         /// <summary>
@@ -150,7 +164,13 @@ namespace System.Net
                 return false;
             }
 
-            return ep.m_Address.Equals(m_Address) && ep.m_Port == m_Port;
+            return ep._address.Equals(_address) && ep._port == _port;
+        }
+
+        // For security, we need to be able to take an IPEndPoint and make a copy that's immutable and not derived.
+        internal IPEndPoint Snapshot()
+        {
+            return new IPEndPoint(Address.Snapshot(), Port);
         }
     }
 }

--- a/source/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/source/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("1.0.7.0")]
+[assembly: AssemblyNativeVersion("1.1.0.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/source/nanoFramework.System.Net/Sockets/SocketsNative.cs
+++ b/source/nanoFramework.System.Net/Sockets/SocketsNative.cs
@@ -13,10 +13,10 @@ namespace System.Net.Sockets
         public static extern int socket(int family, int type, int protocol);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void bind(object socket, byte[] address);
+        public static extern void bind(object socket, EndPoint address);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void connect(object socket, byte[] address, bool fThrowOnWouldBlock);
+        public static extern void connect(object socket, EndPoint endPoint, bool fThrowOnWouldBlock);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern int send(object socket, byte[] buf, int offset, int count, int flags, int timeout_ms);
@@ -41,10 +41,10 @@ namespace System.Net.Sockets
         public static extern void shutdown(object socket, int how, out int err);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern int sendto(object socket, byte[] buf, int offset, int count, int flags, int timeout_ms, byte[] address);
+        public static extern int sendto(object socket, byte[] buf, int offset, int count, int flags, int timeout_ms, EndPoint address);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern int recvfrom(object socket, byte[] buf, int offset, int count, int flags, int timeout_ms, ref byte[] address);
+        public static extern int recvfrom(object socket, byte[] buf, int offset, int count, int flags, int timeout_ms, ref EndPoint address);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void getpeername(object socket, out byte[] address);


### PR DESCRIPTION
## Description
- Add AddressFamily property to IPEndpoint.
- Add snapshot method to IPEndpoint and IPAddress to assist copying objects.
- Add several new fields to IPAddress.
- Add AddressFamily property to IPAddress.
- Add new properties and methods to SocketAddress.
- Replace byte array argument from several calls in NativeSocket with EndPoint type.
- Add several new properties in Socket to accommodate non-blocking connect.
- Adjust Sockets code to new calls to native socket.
- Add code in several Sockets methods to save remote end point and check for connection.
- Add several code bits towards adding support for IPv6.
- Add attribute to hide fields from Debugger on several classes.
- Rename several fields to follow coding guidelines.
- Fix some typos and missing references in comments for documentation.
- Bump native version to 1.1.0.0.

## Motivation and Context
- Simplification of the calls to native socket that have endpoint as argument. 
- Work towards adding support for non-blocking connect.
- Improving reliability on Socket API.
- More work towards adding support for IPv6.
- Closes nanoFramework/Home#482.

## How Has This Been Tested?<!-- (if applicable) -->
- Networking sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>