### PR TITLE
Fix calls address parameters

### DIFF
--- a/source/nanoFramework.System.Net/DNS.cs
+++ b/source/nanoFramework.System.Net/DNS.cs
@@ -39,30 +39,7 @@ namespace System.Net
 
             for (int i = 0; i < cAddresses; i++)
             {
-                byte[] address = addresses[i];
-
-                SocketAddress sockAddress = new SocketAddress(address);
-
-                AddressFamily family;
-
-                //if(SystemInfo.IsBigEndian)
-                ////{
-                //    family = (AddressFamily)((address[0] << 8) | address[1]);
-                //}
-                //else
-                {
-                    family = (AddressFamily)((address[1] << 8) | address[0]);
-                }
-                //port address[2-3]
-
-                if (family == AddressFamily.InterNetwork)
-                {
-                    //This only works with IPv4 addresses
-
-                    uint ipAddr = (uint)((address[7] << 24) | (address[6] << 16) | (address[5] << 8) | (address[4]));
-
-                    ipAddresses[i] = new IPAddress((long)ipAddr);
-                }
+                ipAddresses[i] = new IPAddress(addresses[i]);
             }
 
             ipHostEntry.hostName = canonicalName;

--- a/source/nanoFramework.System.Net/IPAddress.cs
+++ b/source/nanoFramework.System.Net/IPAddress.cs
@@ -75,12 +75,13 @@ namespace System.Net
         /// <param name="address"></param>
         public IPAddress(byte[] address)
         {
-            if (address.Length == IPv4AddressBytes)
+            if (address[0] == (byte)AddressFamily.InterNetwork)
             {
                 _family = AddressFamily.InterNetwork;
-                _address = ((address[3] << 24 | address[2] << 16 | address[1] << 8 | address[0]) & 0x0FFFFFFFF);
+                // need to offset address by 4 (1st are family, 2nd are port
+                _address = ((address[3 + 4] << 24 | address[2 + 4] << 16 | address[1 + 4] << 8 | address[0 + 4]) & 0x0FFFFFFFF);
             }
-            else
+            else if (address[0] == (byte)AddressFamily.InterNetworkV6)
             {
                 _family = AddressFamily.InterNetworkV6;
 
@@ -88,6 +89,11 @@ namespace System.Net
                 {
                     _numbers[i] = (ushort)(address[i * 2] * 256 + address[i * 2 + 1]);
                 }
+            }
+            else
+            {
+                // unsupported address family
+                throw new NotSupportedException();
             }
         }
 

--- a/source/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/source/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("1.1.0.0")]
+[assembly: AssemblyNativeVersion("1.1.1.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/source/nanoFramework.System.Net/Sockets/Socket.cs
+++ b/source/nanoFramework.System.Net/Sockets/Socket.cs
@@ -123,23 +123,20 @@ namespace System.Net.Sockets
                 m_localEndPoint = new IPEndPoint(IPAddress.Any, 0);
             }
 
-            byte[] address = null;
+            EndPoint endPoint = null;
 
             if (fLocal)
             {
-                NativeSocket.getsockname(this, out address);
+                NativeSocket.getsockname(this, out endPoint);
             }
             else
             {
-                NativeSocket.getpeername(this, out address);
+                NativeSocket.getpeername(this, out endPoint);
             }
-
-            SocketAddress socketAddress = new SocketAddress(address);
-            ep = m_localEndPoint.Create(socketAddress);
 
             if (fLocal)
             {
-                m_localEndPoint = ep;
+                m_localEndPoint = endPoint;
             }
 
             return ep;

--- a/source/nanoFramework.System.Net/Sockets/SocketsNative.cs
+++ b/source/nanoFramework.System.Net/Sockets/SocketsNative.cs
@@ -41,16 +41,16 @@ namespace System.Net.Sockets
         public static extern void shutdown(object socket, int how, out int err);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern int sendto(object socket, byte[] buf, int offset, int count, int flags, int timeout_ms, EndPoint address);
+        public static extern int sendto(object socket, byte[] buf, int offset, int count, int flags, int timeout_ms, EndPoint endPoint);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern int recvfrom(object socket, byte[] buf, int offset, int count, int flags, int timeout_ms, ref EndPoint address);
+        public static extern int recvfrom(object socket, byte[] buf, int offset, int count, int flags, int timeout_ms, ref EndPoint endPoint);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void getpeername(object socket, out byte[] address);
+        public static extern void getpeername(object socket, out EndPoint endPoint);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void getsockname(object socket, out byte[] address);
+        public static extern void getsockname(object socket, out EndPoint endPoint);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void getsockopt(object socket, int level, int optname, byte[] optval);

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1.0-preview.{height}",
+  "version": "1.1.1-preview.{height}",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",


### PR DESCRIPTION
## Description
- Fix calls to nativesockets that use bye[] in parameters. They should use EndPoint types.
- Rename parameters for consistency.
- Rework code on callers accordingly.
- Fix code in IPAddress constructor with byte[] parameter.
- Simplified GetHostEntry to use new IPAddress constructor from byte[].
- Bump version to 1.1.1.0-preview.
- Bump native version to 1.1.1.0.

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
- SSL sample pack.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
