### PR TITLE
Add X509Certificate2

### DIFF
--- a/source/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/source/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.1.0")]
+[assembly: AssemblyNativeVersion("100.1.2.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/source/nanoFramework.System.Net/System.Net.nfproj
+++ b/source/nanoFramework.System.Net/System.Net.nfproj
@@ -89,6 +89,7 @@
     <Compile Include="Sockets\SocketsNative.cs" />
     <Compile Include="Sockets\SocketType.cs" />
     <Compile Include="X509Certificates\X509Certificate.cs" />
+    <Compile Include="X509Certificates\X509Certificate2.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="key.snk" />
@@ -101,10 +102,12 @@
     <Reference Include="mscorlib, Version=1.2.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.2.6-preview.16\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.0.8.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.8-preview.20\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />

--- a/source/nanoFramework.System.Net/X509Certificates/X509Certificate2.cs
+++ b/source/nanoFramework.System.Net/X509Certificates/X509Certificate2.cs
@@ -1,0 +1,197 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    /// <summary>
+    /// Represents an X.509 certificate.
+    /// </summary>
+    public class X509Certificate2 : X509Certificate
+    {
+#pragma warning disable S3459 // Unassigned members should be removed
+        // these fields are required and set in native code
+        private readonly byte[] _privateKey;
+#pragma warning restore S3459 // Unassigned members should be removed
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="X509Certificate2"/> class.
+        /// </summary>
+        public X509Certificate2()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using information from a byte array.
+        /// </summary>
+        /// <param name="rawData">A byte array containing data from an X.509 certificate.</param>
+        public X509Certificate2(byte[] rawData)
+            : base(rawData)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a byte array and a password.
+        /// </summary>
+        /// <param name="rawData">A byte array containing data from an X.509 certificate.</param>
+        /// <param name="password">The password required to access the X.509 certificate data.</param>
+        public X509Certificate2(byte[] rawData, string password)
+            : base(rawData, password)
+        {
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 certificate.
+        /// </summary>
+        /// <param name="certificate">A string containing a X.509 certificate.</param>
+        /// <remarks>
+        /// This methods is exclusive of nanoFramework. The equivalent .NET constructor accepts a file name as the parameter.
+        /// </remarks>
+        public X509Certificate2(string certificate)
+            : base(certificate)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 certificate and a password used to access the certificate.
+        /// </summary>
+        /// <param name="certificate">A string containing a X.509 certificate.</param>
+        /// <param name="password">The password required to access the X.509 certificate data.</param>
+        /// <remarks>
+        /// This methods is exclusive of nanoFramework. The equivalent .NET constructor accepts a file name as the parameter.
+        /// </remarks>
+        public X509Certificate2(string certificate, string password)
+            : base(certificate, password)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 public certificate, the private key and a password used to access the certificate.
+        /// </summary>
+        /// <param name="certificate">A string containing a X.509 certificate.</param>
+        /// <param name="key">A string containing a PEM private key.</param>
+        /// <param name="password">The password required to access the X.509 certificate data.</param>
+        /// <remarks>
+        /// This methods is exclusive of nanoFramework. There is no equivalent in .NET framework.
+        /// </remarks>
+        public X509Certificate2(string certificate, string key, string password)
+            : base(certificate, password)
+        {
+            var tempKey = Encoding.UTF8.GetBytes(key);
+
+            //////////////////////////////////////////////
+            // because this is parsing from a string    //
+            // we need to keep the terminator           //
+            //////////////////////////////////////////////
+            var keyBuffer = new byte[tempKey.Length + 1];
+            Array.Copy(tempKey, keyBuffer, tempKey.Length);
+            keyBuffer[keyBuffer.Length - 1] = 0;
+
+            _privateKey = keyBuffer;
+
+            DecodePrivateKeyNative(keyBuffer, password);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 public certificate, the private key and a password used to access the certificate.
+        /// </summary>
+        /// <param name="rawData">A byte array containing data from an X.509 certificate.</param>
+        /// <param name="key">A string containing a PEM private key.</param>
+        /// <param name="password">The password required to access the X.509 certificate data.</param>
+        /// <remarks>
+        /// This methods is exclusive of nanoFramework. There is no equivalent in .NET framework.
+        /// </remarks>
+        public X509Certificate2(byte[] rawData, string key, string password)
+            : base(rawData, password)
+        {
+            var tempKey = Encoding.UTF8.GetBytes(key);
+
+            //////////////////////////////////////////////
+            // because this is parsing from a string    //
+            // we need to keep the terminator           //
+            //////////////////////////////////////////////
+            var keyBuffer = new byte[tempKey.Length + 1];
+            Array.Copy(tempKey, keyBuffer, tempKey.Length);
+            keyBuffer[keyBuffer.Length - 1] = 0;
+
+            _privateKey = keyBuffer;
+
+            DecodePrivateKeyNative(keyBuffer, password);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 public certificate, the private key and a password used to access the certificate.
+        /// </summary>
+        /// <param name="rawData">A byte array containing data from an X.509 certificate.</param>
+        /// <param name="key">A byte array containing a PEM private key.</param>
+        /// <param name="password">The password required to access the X.509 certificate data.</param>
+        /// <remarks>
+        /// This methods is exclusive of nanoFramework. There is no equivalent in .NET framework.
+        /// </remarks>
+        public X509Certificate2(byte[] rawData, byte[] key, string password)
+            : base(rawData, password)
+        {
+            _privateKey = key;
+
+            DecodePrivateKeyNative(key, password);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether an X509Certificate2 object contains a private key.
+        /// </summary>
+        /// <value><see langword="true"/> if the <see cref="X509Certificate2"/> object contains a private key; otherwise, <see langword="false"/>.</value>
+        public bool HasPrivateKey
+        {
+            get
+            {
+                return (_privateKey != null);
+            }
+        }
+
+        /// <summary>
+        /// Gets the date in local time after which a certificate is no longer valid.
+        /// </summary>
+        /// <value>A <see cref="DateTime"/> object that represents the expiration date for the certificate.</value>
+        public DateTime NotAfter
+        {
+            get
+            {
+                return _expirationDate;
+            }
+        }
+
+        /// <summary>
+        /// Gets the date in local time on which a certificate becomes valid.
+        /// </summary>
+        /// <value>A <see cref="DateTime"/> object that represents the effective date of the certificate.</value>
+        public DateTime NotBefore
+        {
+            get
+            {
+                return _effectiveDate;
+            }
+        }
+
+        /// <summary>
+        /// Gets the raw data of a certificate.
+        /// </summary>
+        /// <value>The raw data of the certificate as a byte array.</value>
+        public byte[] RawData
+        {
+            get
+            {
+                return base.GetRawCertData();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern void DecodePrivateKeyNative(byte[] keyBuffer, string password);
+    }
+}

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1.1-preview.{height}",
+  "version": "1.2.0-preview.{height}",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",


### PR DESCRIPTION
## Description
- Add X509Certificate2 class.
- Bump native version to 100.1.2.0.
- Bump version to 1.2.0-preview.

## Motivation and Context
- Closes nanoFramework/Home#540.

## How Has This Been Tested?<!-- (if applicable) -->
- SSL sample: able to parse certificate with private key, able to connect to server using client certificate.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

