### PR TITLE
Fix return value of GetEndpoint()

### DIFF
--- a/source/nanoFramework.System.Net/Sockets/Socket.cs
+++ b/source/nanoFramework.System.Net/Sockets/Socket.cs
@@ -19,7 +19,7 @@ namespace System.Net.Sockets
          * The m_Handle field MUST be the first field in the Socket class; it is expected by
          * the SPOT.NET.SocketNative class.
          */
-   //     [FieldNoReflection]
+        //     [FieldNoReflection]
         internal int m_Handle = -1;
 
         [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]

--- a/source/nanoFramework.System.Net/Sockets/Socket.cs
+++ b/source/nanoFramework.System.Net/Sockets/Socket.cs
@@ -116,8 +116,6 @@ namespace System.Net.Sockets
                 throw new ObjectDisposedException();
             }
 
-            EndPoint ep = null;
-
             if (m_localEndPoint == null)
             {
                 m_localEndPoint = new IPEndPoint(IPAddress.Any, 0);
@@ -139,7 +137,7 @@ namespace System.Net.Sockets
                 m_localEndPoint = endPoint;
             }
 
-            return ep;
+            return endPoint;
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The socket struct has two fields for endpoints, a local and a remote endpoint. These files have always been Null, so the get request to these fields always returned Null. This makes it impossible to use methods like SendTo() and ReceiveFrom().

## Motivation and Context
Nevertheless, the send() and receive() methods worked correctly. But sometimes it is necessary to determine the IP and port address of a connected device.
The problem was that there were two endpoints defined and initialized with Null in the GetEndPoint() method. Only one of them got updated but then the other one was used as return value. I removed the first one and adjusted the return value.

## How Has This Been Tested?<!-- (if applicable) -->
This has been tested with a custom STM32F427 based MCU board with network interface. Both client and server modes have been used as test applications.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: Martin Kuhn martin.kuhn@csa.ch
