### PR TITLE
Add UseStoredDeviceCertificate to SecureSocket

### DIFF
--- a/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.3.3")]
+[assembly: AssemblyNativeVersion("100.1.3.4")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/nanoFramework.System.Net/Security/NetworkSecurity.cs
+++ b/nanoFramework.System.Net/Security/NetworkSecurity.cs
@@ -70,10 +70,20 @@ namespace System.Net.Security
     internal static class SslNative
     {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern int SecureServerInit(int sslProtocols, int sslCertVerify, X509Certificate certificate, X509Certificate ca);
+        internal static extern int SecureServerInit(
+            int sslProtocols,
+            int sslCertVerify,
+            X509Certificate certificate,
+            X509Certificate ca,
+            bool useDeviceCertificate);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern int SecureClientInit(int sslProtocols, int sslCertVerify, X509Certificate certificate, X509Certificate ca);
+        internal static extern int SecureClientInit(
+            int sslProtocols,
+            int sslCertVerify,
+            X509Certificate certificate,
+            X509Certificate ca,
+            bool useDeviceCertificate);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void SecureAccept(int contextHandle, object socket);

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.6.4-preview.{height}",
+  "version": "1.6.5-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## Description
- Update documentation comments to reflect this new possibility.
- Update calls to native interface.
- Bump versions.

## Motivation and Context
- Allow developers to use internally stored certificate.

## How Has This Been Tested?<!-- (if applicable) -->
- SSL sample in samples repo.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
